### PR TITLE
Fix query issue

### DIFF
--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -8,7 +8,7 @@ import { graphql, useStaticQuery } from "gatsby"
 const Footer = props => {
   const data = useStaticQuery(graphql`
     query {
-      allContentfulLocationPage(filter: { node_locale: { eq: "en-US" } }) {
+      allContentfulLocationPage(filter: { node_locale: { eq: "en" } }) {
         edges {
           node {
             heading

--- a/src/components/locations/DatesCalendar.js
+++ b/src/components/locations/DatesCalendar.js
@@ -15,7 +15,7 @@ const DatesCalendar = ({ eventsPage, city, mail }) => {
 
   const data = useStaticQuery(graphql`
     query {
-      allContentfulDates(filter: { node_locale: { eq: "en-US" } }) {
+      allContentfulDates(filter: { node_locale: { eq: "en" } }) {
         edges {
           node {
             location {

--- a/src/pages/apply.js
+++ b/src/pages/apply.js
@@ -111,7 +111,7 @@ export default apply
 
 export const pageQuery = graphql`
   query {
-    allContentfulLocationPage(filter: { node_locale: { eq: "en-US" } }) {
+    allContentfulLocationPage(filter: { node_locale: { eq: "en" } }) {
       edges {
         node {
           heading

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -28,7 +28,7 @@ export default blog
 
 export const pageQuery = graphql`
   query BlogIndexQuery {
-    allContentfulBlogPost(filter: { node_locale: { eq: "en-US" } }) {
+    allContentfulBlogPost(filter: { node_locale: { eq: "en" } }) {
       edges {
         node {
           title

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -426,7 +426,7 @@ export const pageQuery = graphql`
     nils: file(relativePath: { eq: "nils.png" }) {
       ...fixedImage
     }
-    allContentfulLocationPage(filter: { node_locale: { eq: "en-US" } }) {
+    allContentfulLocationPage(filter: { node_locale: { eq: "en" } }) {
       edges {
         node {
           heading

--- a/src/pages/locations.js
+++ b/src/pages/locations.js
@@ -153,7 +153,7 @@ export default Locations
 
 export const pageQuery = graphql`
   query LocationPageQuery {
-    allContentfulLocationPage(filter: { node_locale: { eq: "en-US" } }) {
+    allContentfulLocationPage(filter: { node_locale: { eq: "en" } }) {
       edges {
         node {
           heading

--- a/src/pages/program/remote.js
+++ b/src/pages/program/remote.js
@@ -213,7 +213,7 @@ export const pageQuery = graphql`
     remote: file(relativePath: { eq: "remote.png" }) {
       ...fluidImage
     }
-    page: allContentfulCodeAtHome(filter: { node_locale: { eq: "en-US" } }) {
+    page: allContentfulCodeAtHome(filter: { node_locale: { eq: "en" } }) {
       edges {
         node {
           pageTitle {
@@ -275,6 +275,13 @@ export const pageQuery = graphql`
                 _2
                 _3
               }
+            }
+          }
+          tracks {
+            tracks {
+              link
+              text
+              heading
             }
           }
           faq {


### PR DESCRIPTION
gatsby-plugin-intl has 'en' or 'de' as locales, so I changed the locale settings in Contentful to have the same and use them as variables in the queries - this is a quick fix to change all provisory filters 'en-US' into 'en'.

+ add 'tracks' query field to remote.js 

The correct localization filter in queries will be there with the /translation branch ;)