### PR TITLE
remove button for codeathome bootcamp since deadline is already passed

### DIFF
--- a/src/components/program/remote/Hero.js
+++ b/src/components/program/remote/Hero.js
@@ -52,14 +52,14 @@ const Hero = ({
                 </span>
               </p>
             </div>
-            <div className="col-md-3 d-flex justify-content-center align-items-center">
+            {/* <div className="col-md-3 d-flex justify-content-center align-items-center">
               <Button
                 text={<FormattedMessage id="program.remote.hero.button"/>}
                 isExternal={true}
                 link={link}
                 primary={true}
               ></Button>
-            </div>
+            </div> */}
           </div>
         </div>
         <div className="col-md-6 my-auto">


### PR DESCRIPTION
remove button for codeathome bootcamp since deadline is already passed :)
For now it's just commented out, we could implement a logic to check if the date of the bootcamp start is already in the past to remove the button!