### PR TITLE
Optimize Location page: Office and Dates + Quick fix: projects in md/lg screens 

### DIFF
--- a/src/components/locations/DatesCalendar.js
+++ b/src/components/locations/DatesCalendar.js
@@ -152,7 +152,7 @@ const DatesCalendar = ({ eventsPage, city, mail }) => {
         </div>
         <div className="row">
           <div className="col">
-            <div className="row">
+            <div className="row justify-content-center mt-3">
               {dates[currentMonth] !== null ? (
                 <>
                   {Object.keys(dates[currentMonth]).length > 5 ? (

--- a/src/components/locations/DatesCalendar.js
+++ b/src/components/locations/DatesCalendar.js
@@ -111,6 +111,19 @@ const DatesCalendar = ({ eventsPage, city, mail }) => {
 
   const dates = locationDates[0].node
 
+  const getMonthClassNames = (date, index) => {
+    let classNames = "col " 
+    console.log(index)
+    if (currentMonth === date.format("MMMM").toLowerCase()) {
+      classNames += 'datesCalendar--dates_active'
+    } else if (index > 2) {
+      classNames += 'datesCalendar--dates' + ' d-none d-md-block'
+    } else {
+      classNames += 'datesCalendar--dates'
+    }
+    return classNames
+  }
+
   return (
     <Container className="datesCalendar">
       <Heading
@@ -124,13 +137,9 @@ const DatesCalendar = ({ eventsPage, city, mail }) => {
       />
       <div className="datesCalendar--card">
         <div className="row">
-          {month.map(date => (
+          {month.map((date, index) => (
             <div
-              className={
-                currentMonth === date.format("MMMM").toLowerCase()
-                  ? "col datesCalendar--dates_active"
-                  : "col datesCalendar--dates"
-              }
+              className={getMonthClassNames(date, index)}
               key={date.month()}
               onClick={() => setCurrentMonth(date.format("MMMM").toLowerCase())}
               onKeyDown={() => null}

--- a/src/components/program/Projects.js
+++ b/src/components/program/Projects.js
@@ -21,8 +21,8 @@ const Projects = () => {
         heading={<FormattedMessage id={"projects.heading"} />}
         subheading={<FormattedMessage id={"projects.subheading"} />}
       />
-      <div className="row d-flex">
-        <div className="col-md-4 py-5 justify-content-center align-self-center">
+      <div className="row d-flex justify-content-center">
+        <div className="col-md-6 col-xl-4 py-1 justify-content-center align-self-center">
           <div className="card h-75 mt-5">
             <h3 className="text-center projects--heading">
               <span className="highlighted">
@@ -66,7 +66,7 @@ const Projects = () => {
             </div>
           </div>
         </div>
-        <div className="col-md-4 py-5 justify-content-center align-self-center">
+        <div className="col-md-6 col-xl-4 py-1 justify-content-center align-self-center">
           <div className="card h-100 mt-5">
             <h3 className="text-center projects--heading">
               <span className="highlighted">
@@ -125,7 +125,7 @@ const Projects = () => {
             </div>
           </div>
         </div>
-        <div className="col-md-4 py-5 justify-content-center align-self-center">
+        <div className="col-md-6 col-xl-4 py-1 justify-content-center align-self-center">
           <div className="card h-75 mt-5">
             <h3 className="text-center projects--heading">
               <span className="highlighted">

--- a/src/styles/locations/_location.scss
+++ b/src/styles/locations/_location.scss
@@ -165,22 +165,14 @@
   &--img {
     background-repeat: no-repeat;
     background-size: cover;
-    height: 35vh;
+    height: 65vh;
+    min-height: 580px;
   }
   &--card {
-    z-index: 1;
-    right: 0;
-    bottom: 0;
-    box-shadow: 0 5px 25px -5px rgba(15, 18, 63, 0) !important;
-    transition: box-shadow 0.5s;
-    background-color: #ffffff;
-    will-change: transform;
-    box-shadow: 10px 0px 20px rgba(30, 49, 71, 0.206692);
-    border-top-left-radius: 6px;
-    padding: 1rem;
+    padding: 1rem .5rem;
   }
   &--heading {
-    font-size: 25px;
+    font-size: 20px;
     line-height: 28px;
   }
   &--smalltext {
@@ -198,17 +190,28 @@
     color: $color-gl;
   }
 
-  @media (max-width: 767px) {
-    &--img {
-      height: 70vh;
-    }
-
+  @media (max-width: 1000px) {
     &--smalltext {
       font-size: 12px;
     }
+  }
+
+  @media (max-width: 767px) {
+    &--img {
+      height: 30vh;
+    }
 
     &--heading {
-      font-size: 20px;
+      font-size: 18px;
+    }
+  }
+
+
+
+  @media (min-width: 1200px) {
+    &--img {
+      height: 40vh;
+      min-height: 500px;
     }
   }
 }

--- a/src/templates/location.js
+++ b/src/templates/location.js
@@ -318,26 +318,32 @@ class location extends Component {
                 }
               />
               <div className="row">
-                <div
-                  className="col-md-7 office--img"
-                  style={{
-                    backgroundImage: location.officeImg
-                      ? `url(${location.officeImg.file.url})`
-                      : null,
-                  }}
-                >
-                  <div className="w-75 office--card position-absolute">
+                <div className="col-md-7">
+                  <div
+                    className="office--img"
+                    style={{
+                      backgroundImage: location.officeImg
+                        ? `url(${location.officeImg.file.url})`
+                        : null,
+                    }}
+                  >
+                  </div>
+                  
+                </div>
+                {location.officeText ? (
+                  <div className="col-md-5">
+                    <div className="office--card">
                     <h3 className="office--heading">
                       <FormattedMessage id="location.office.visit" />{" "}
                       {location.officeName}
                     </h3>
-                    <div className="row mt-4">
+                    <div className="row mt-3">
                       <img src={pin2} alt="pin" className="h-75 mx-3" />
                       <p className=" office--smalltext">
                         {location.officeAdress}
                       </p>
                     </div>
-                    <div className="row mt-2">
+                    <div className="row">
                       <img src={getDirection} alt="pin" className="h-75 mx-3" />
                       <a
                         href={location.officeLink}
@@ -347,10 +353,7 @@ class location extends Component {
                       </a>
                     </div>
                   </div>
-                </div>
-                {location.officeText ? (
-                  <div className="col-md-5">
-                    <div className="row pl-5 d-flex h-100 mt-5 pr-5">
+                    <div className="px-2 d-flex">
                       <p className="align-self-center justify-content-center office--text">
                         {location.officeText.json.content[0].content[0].value}
                       </p>


### PR DESCRIPTION
**Location office**
-  better layout and css for mobile and desktop: No overlay of office card and image -> different structure: office card now is placed on top of the office text row (between img and text in mobile), 
- some padding and size adjustments
- esp. better responsive design of the img, so that its height fits to the text column next to it

**Location Dates**
- display only 3 months (instead of 5) when the screen width ist lower or equal the md width
- Design of Location event dates: centered the events + added space 

**Projects (Programm pages)**
Quick fix: Projects were displayed in 3 columns when screen width was medium or large -> width was not sufficient so that the text in the project columns could be hardly read