### PR TITLE
add message when the service worker has a new version

### DIFF
--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -1,0 +1,9 @@
+export const onServiceWorkerUpdateReady = () => {
+  const answer = window.confirm(
+    `This application has been updated. ` +
+      `Reload to display the latest version?`
+  )
+  if (answer === true) {
+    window.location.reload()
+  }
+}


### PR DESCRIPTION
Several issues of techies dont see an apply date. Potential fix.

https://www.gatsbyjs.com/docs/how-to/performance/add-offline-support-with-a-service-worker/