### PR TITLE
#397 Adds next batch date text also when application is closed

### DIFF
--- a/src/templates/location.js
+++ b/src/templates/location.js
@@ -188,6 +188,9 @@ class location extends Component {
                       ) : (
                         <p className="batch-text">
                           <FormattedMessage id="location.nextBatch" />
+                          <span className="a-black">
+                            {location.nextBatchDate}
+                          </span>
                         </p>
                       )}
                     </div>


### PR DESCRIPTION
This allows to show the next batch date also on the location page, allowing locations to reduce the number of questions asking for that information